### PR TITLE
Register app subdomain with AWS DNS registry 

### DIFF
--- a/infra/personal_domain/.terraform.lock.hcl
+++ b/infra/personal_domain/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/personal_domain/acm.tf
+++ b/infra/personal_domain/acm.tf
@@ -1,0 +1,51 @@
+
+# 1. Request the certificate
+# The 'validation_method' is set to DNS, which is the best way to automate this.
+resource "aws_acm_certificate" "my_certificate" {
+  domain_name               = aws_route53_zone.my_domain_zone.name
+  subject_alternative_names = ["*.${aws_route53_zone.my_domain_zone.name}"]
+  validation_method         = "DNS"
+
+  # Recommended lifecycle block to prevent issues when replacing a certificate in use
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Use a local variable to create a unique set of validation records
+locals {
+  validation_records = distinct([
+    for dvo in aws_acm_certificate.my_certificate.domain_validation_options : {
+      name  = dvo.resource_record_name
+      type  = dvo.resource_record_type
+      value = dvo.resource_record_value
+    }
+  ])
+}
+
+# 2. Create the DNS records needed for validation
+# This resource now uses the unique list of records from the local variable.
+resource "aws_route53_record" "acm_validation_records" {
+  for_each = {
+    for record in local.validation_records : record.name => record
+  }
+  
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.value]
+  zone_id = aws_route53_zone.my_domain_zone.zone_id
+  ttl     = 60
+}
+
+# 3. Wait for the certificate to be validated
+# This resource explicitly depends on the DNS records being created and tells
+# Terraform to wait for ACM to finish the validation process.
+resource "aws_acm_certificate_validation" "acm_validation" {
+  certificate_arn         = aws_acm_certificate.my_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.acm_validation_records : record.fqdn]
+}
+
+# Output the certificate ARN for use in other resources (like your ALB)
+output "acm_certificate_arn" {
+  value = aws_acm_certificate_validation.acm_validation.certificate_arn
+}

--- a/infra/personal_domain/provider.tf
+++ b/infra/personal_domain/provider.tf
@@ -1,0 +1,34 @@
+# TODO (navneetkapur): Centralize provider configuration to remove
+# duplication across modules and files.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"  # Specify your AWS region
+}
+
+data "aws_caller_identity" "current" {}
+
+# variable "infra_identifier" {
+#   type        = string
+#   description = "Identifier for the infrastructure, e.g., 'personal_domain'"
+#   default     = "personal_domain"
+# }
+
+# TODO (navneetkapur): Leverage Helm/Kustomize for s3 path management
+terraform {
+  backend "s3" {
+    bucket         = "experiments-infra-state"
+    key            = "infra/personal_domain/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "terraform-locks"   # Optional for state locking
+    encrypt        = true
+  }
+}

--- a/infra/personal_domain/route_53_zone.tf
+++ b/infra/personal_domain/route_53_zone.tf
@@ -1,0 +1,9 @@
+# Create a public hosted zone for your domain
+resource "aws_route53_zone" "my_domain_zone" {
+  name = "navneetkapur.com" 
+}
+
+# Output the nameservers created by AWS
+output "route53_nameservers" {
+  value = aws_route53_zone.my_domain_zone.name_servers
+}


### PR DESCRIPTION
* Personal Domain navneetkapur.com created via GoDaddy
* Set up the Route 53 Zone for the above and obtain nameservers
  * Deployed on local
  * Nameservers updated on GoDaddy for domain
* Once propagated, certificated generated via ACM to prove ownership


Note - No Alias record created for root domain yet. Will test with subdomain CNAME record for the app first